### PR TITLE
Fix menu not being hidden behind header in certain situations

### DIFF
--- a/src/routes/header/_index.scss
+++ b/src/routes/header/_index.scss
@@ -8,6 +8,10 @@
   position: relative;
   z-index: 1;
 
+  // To fix a ridiculous 10 year old bug in iOS safari - or maybe it just deals with z-index or stacking contexts differenly from other browsers?
+  // https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/
+  transform: translate3d(0, 0, 0);
+
   text-align: center;
 
   &--logo {


### PR DESCRIPTION
Issue seems to exist only on iOS Safari and did not show up at all during testing on Firefox/Chrome.

Open the mobile header menu, scroll down, then close it, and somehow the menu is in front of the header company logo. Makes no sense to me. 